### PR TITLE
Add theme toggle for capacity planner UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="nl">
+<html lang="nl" data-theme="dark">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -19,6 +19,10 @@
         <div class="title">Capaciteitsplanner</div>
       </div>
       <div class="actions">
+        <button class="btn ghost icon" id="btn-theme" type="button" aria-label="Schakel naar licht thema">
+          <span class="icon" aria-hidden="true">🌙</span>
+          <span class="label">Licht thema</span>
+        </button>
         <button class="btn secondary" onclick="openModal('about')">Over</button>
         <button class="btn" onclick="openDrawer()">Nieuwe taak</button>
       </div>

--- a/js/main.js
+++ b/js/main.js
@@ -27,9 +27,59 @@ window.clearTask = clearTask;
 window.editTask = editTask;
 window.setTab = setTab;
 
+const THEME_KEY = "planner-theme";
+
+function applyTheme(theme) {
+  const nextTheme = theme === "dark" ? "light" : "dark";
+  document.documentElement.setAttribute("data-theme", theme);
+
+  const button = document.getElementById("btn-theme");
+  if (button) {
+    const icon = button.querySelector(".icon");
+    const label = button.querySelector(".label");
+    if (icon) icon.textContent = nextTheme === "light" ? "☀️" : "🌙";
+    if (label) label.textContent = `${nextTheme === "light" ? "Licht" : "Donker"} thema`;
+    button.setAttribute(
+      "aria-label",
+      `Schakel naar ${nextTheme === "light" ? "licht" : "donker"} thema`
+    );
+  }
+}
+
+function initThemeToggle() {
+  let storedTheme = null;
+  try {
+    storedTheme = localStorage.getItem(THEME_KEY);
+  } catch (error) {
+    console.warn("Kon thema voorkeur niet laden", error);
+  }
+  const safeStoredTheme = storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+  const prefersLight = window.matchMedia
+    ? window.matchMedia("(prefers-color-scheme: light)").matches
+    : false;
+  const initialTheme = safeStoredTheme ?? (prefersLight ? "light" : "dark");
+  applyTheme(initialTheme);
+
+  const button = document.getElementById("btn-theme");
+  if (!button) return;
+
+  button.addEventListener("click", () => {
+    const current = document.documentElement.getAttribute("data-theme") || "dark";
+    const next = current === "dark" ? "light" : "dark";
+    applyTheme(next);
+    try {
+      localStorage.setItem(THEME_KEY, next);
+    } catch (error) {
+      console.warn("Kon thema niet opslaan", error);
+    }
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   fillFilters();
   renderAll();
+
+  initThemeToggle();
 
   const resetButton = document.getElementById("btn-reset");
   if (resetButton) resetButton.addEventListener("click", resetFilters);

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,5 @@
   :root{
+    color-scheme: dark;
     --bg:#0f1115;
     --bg-2:#161b22;
     --gloss:#161b22;
@@ -25,6 +26,33 @@
     --leave-feestdag:#eab308;
     --leave-deeltijd:#64748b;
   }
+  :root[data-theme="light"]{
+    color-scheme: light;
+    --bg:#f4f6fb;
+    --bg-2:#ffffff;
+    --gloss:#f8fafc;
+    --panel:#ffffff;
+    --panel-2:#eef2ff;
+    --stroke:rgba(15,23,42,.12);
+    --stroke-2:rgba(15,23,42,.08);
+    --text:#0f172a;
+    --muted:#475569;
+    --accent:#dc2626;
+    --accent-2:#b91c1c;
+    --ok:#16a34a;
+    --warn:#b45309;
+    --danger:#b91c1c;
+    --chip:#e2e8f0;
+    --focus:#f59e0b;
+    --shadow:0 20px 40px rgba(15,23,42,.12);
+    --leave-vakantie:#16a34a;
+    --leave-verlof:#0284c7;
+    --leave-ziek:#e11d48;
+    --leave-training:#7c3aed;
+    --leave-thuis:#ea580c;
+    --leave-feestdag:#ca8a04;
+    --leave-deeltijd:#475569;
+  }
   *{box-sizing:border-box}
   html,body{height:100%}
   body{
@@ -33,6 +61,7 @@
     color:var(--text);
     background:var(--bg);
     overflow-x:hidden;
+    transition:background .3s ease, color .3s ease;
   }
 
   /* Layout */
@@ -72,6 +101,10 @@
     color:white; font-weight:600;
     font:inherit;
     transition:background .2s ease, transform .2s ease;
+    display:inline-flex;
+    align-items:center;
+    gap:8px;
+    justify-content:center;
   }
   .btn:hover{transform:translateY(-1px);}
   .btn.secondary{background:transparent;border:1px solid var(--stroke);color:var(--text)}
@@ -79,6 +112,9 @@
   .btn.ghost{background:transparent;border:1px solid var(--stroke);color:var(--text)}
   .btn.ghost:hover{background:var(--panel-2);}
   .btn.small{padding:8px 10px;font-size:12px}
+  .btn.icon{padding:8px 10px;font-size:12px}
+  .btn.icon .icon{font-size:16px; line-height:1;}
+  .btn.icon .label{font-weight:600;}
 
   /* Sidebar */
   .side{
@@ -96,7 +132,7 @@
     padding:14px;
     margin-bottom:14px;
   }
-  .panel h3{margin:0 0 10px; font-size:14px; color:#eaeef5; letter-spacing:.3px}
+  .panel h3{margin:0 0 10px; font-size:14px; color:var(--text); letter-spacing:.3px}
   label{display:block; font-size:12px; color:var(--muted); margin:10px 0 8px}
   input,select{
     width:100%; padding:10px 12px;


### PR DESCRIPTION
## Summary
- add a theme toggle button to the navigation bar and set an initial data-theme
- define a light theme palette and button styling updates to support both modes
- apply the persisted theme preference on load and update the toggle label/icon dynamically

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e39c0880dc832b94a5d09814ece20a