### PR TITLE
Improve skill filter performance

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -11,6 +11,7 @@ import {
   parseISODate,
   formatWeekLabel,
   workshopName,
+  debounce,
 } from "./utils.js";
 
 export function fillFilters() {
@@ -34,9 +35,12 @@ export function fillFilters() {
 
   const skillInput = document.getElementById("f-skill");
   if (skillInput) {
-    skillInput.addEventListener("input", (event) => {
-      state.filters.skill = event.target.value;
+    const handleSkillChange = debounce((value) => {
+      state.filters.skill = value;
       renderAll();
+    }, 200);
+    skillInput.addEventListener("input", (event) => {
+      handleSkillChange(event.target.value);
     });
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -154,3 +154,16 @@ export function formatISODate(date) {
   const d = String(date.getUTCDate()).padStart(2, "0");
   return `${y}-${m}-${d}`;
 }
+
+export function debounce(callback, delay) {
+  let timerId = null;
+  return (...args) => {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+    }
+    timerId = setTimeout(() => {
+      timerId = null;
+      callback(...args);
+    }, delay);
+  };
+}


### PR DESCRIPTION
## Summary
- debounce the skill filter input to avoid triggering full rerenders on every keystroke
- add a reusable debounce utility for future throttled handlers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7be706da8832b9241163d6c255ed7